### PR TITLE
k.data is now readonly in Chrome.  Remove unnecessary assignment.

### DIFF
--- a/CesiumHeatmap.js
+++ b/CesiumHeatmap.js
@@ -694,7 +694,6 @@ CHInstance.prototype.updateLayer = function () {
 					l[o - 1] = n[q + 2];
 					l[o] = j ? n[q + 3] : r
 				}
-				k.data = l;
 				this.ctx.putImageData(k, a, b);
 				this._renderBoundaries = [1e3, 1e3, 0, 0]
 			}, getValueAt: function (a) {


### PR DESCRIPTION
 the line l = k.data sets the reference to k.data, so if you change l it changes k.data.  

This line throws an exception k.data is now readonly in Chrome.  It is not needed.